### PR TITLE
Fix mobile menu issue when scrolling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -359,7 +359,7 @@ Mobile Styling!
 		height: 100%;
 		padding-top: 70px;
 		overflow: hidden;
-		position:absolute;
+		position: fixed;
 		display:inline-block;
 		z-index: 10;
 		border-radius: 0px;
@@ -427,6 +427,10 @@ Mobile Styling!
 	.toggle-nav:matches(:hover, :active, :focus) {
 		color:white;
 		text-decoration: none;
+	}
+
+	.toggle-nav.active{
+		position: fixed;
 	}
 
 	#footer {


### PR DESCRIPTION
The mobile menu used to only be 100% height of the browser, so the
footer below wasn’t covered. Switching to fixed while active keeps it
covering the screen and looking better.
